### PR TITLE
fix(ci): GitHub Deploymentsへの書き込み権限を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  deployments: write
+
 jobs:
   deploy-backend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
エラー内容 Resource not accessible by integration (403 Forbidden) は、GitHub ActionsからDeploymentを作成する権限が不足していることを示しています。

先ほど [deploy.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) に追加していただいた以下の権限設定により、Cloudflare Pages Actionが

GitHub上にデプロイメントステータスを作成できるようになり、エラーが解消されるはずです。