### PR TITLE
fix(ci): フロントエンドビルド時にVITE_GOOGLE_CLIENT_IDを注入

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,7 @@ jobs:
           # Backend URL should be set in GitHub Secrets or hardcoded if known
           # Example: https://body-tracker-backend.<your-subdomain>.workers.dev
           VITE_API_BASE: ${{ secrets.VITE_API_BASE }}
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
 
       - name: Deploy Frontend
         uses: cloudflare/pages-action@v1


### PR DESCRIPTION
# fix: デプロイフローとフロントエンドビルドの修正

## 概要
本番環境へのデプロイを成功させるためのCI/CD設定の修正、およびフロントエンドのビルドエラー修正を行いました。

## 変更点

### CI/CD (GitHub Actions)
- **ロックファイルの管理**: `pnpm-lock.yaml` をGit管理対象に追加し、CI上での依存関係解決を安定化させました。
- **権限設定**: `deploy.yml` に `deployments: write` 権限を追加し、Cloudflare Pages Actionによるデプロイメントステータスの更新エラーを解消しました。
- **ビルド順序**: バックエンドおよびフロントエンドのビルド前に、依存している `@body-tracker/shared` パッケージのビルドステップを追加しました。
- **環境変数**: フロントエンドのビルド時に `VITE_GOOGLE_CLIENT_ID` が注入されるように修正しました。

### フロントエンド
- **App.tsx**:
    - 未定義変数 `shouldShowProfileModal` を修正し、正しい変数 `showNameRegistration` を使用するように変更しました。
    - 未使用変数エラーを解消しました。
    - 不要な二重否定 (`!!`) を削除し、コードを簡潔にしました。

### インフラストラクチャ
- Cloudflare Pagesプロジェクト `body-tracker` が作成されていることを確認しました。

## 確認事項
- [x] GitHub Actionsのデプロイジョブが正常に完了すること
- [x] デプロイされたサイト (`https://body-tracker.pages.dev`) でGoogleログインボタンが正常に表示されること（"CLIENT_ID 未設定" エラーが出ないこと）