### PR TITLE
feat: 記録の更新・論理削除機能の実装とフォームの共通化

### DIFF
--- a/apps/backend/drizzle/0003_condemned_thaddeus_ross.sql
+++ b/apps/backend/drizzle/0003_condemned_thaddeus_ross.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "body_records" ADD COLUMN "deleted_at" timestamp with time zone;

--- a/apps/backend/drizzle/meta/0003_snapshot.json
+++ b/apps/backend/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,153 @@
+{
+  "id": "b993f6de-50cc-4a84-b909-8db56a7d391b",
+  "prevId": "d70f0ebc-3304-4e0e-8230-93f4cbee57d5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.body_records": {
+      "name": "body_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_fat_percentage": {
+          "name": "body_fat_percentage",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_date": {
+          "name": "recorded_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "body_records_user_id_users_id_fk": {
+          "name": "body_records_user_id_users_id_fk",
+          "tableFrom": "body_records",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1763990395670,
       "tag": "0002_handy_mordo",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1766006871106,
+      "tag": "0003_condemned_thaddeus_ross",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -28,6 +28,7 @@ export const bodyRecords = pgTable('body_records', {
   notes: text('notes'),
   createdAt: timestamp('created_at', { withTimezone: true }),
   updatedAt: timestamp('updated_at', { withTimezone: true }),
+  deletedAt: timestamp('deleted_at', { withTimezone: true }),
 });
 
 export type User = typeof users.$inferSelect;

--- a/apps/frontend/src/dashboard/RecordForm.tsx
+++ b/apps/frontend/src/dashboard/RecordForm.tsx
@@ -1,0 +1,126 @@
+import { BODY_FAT_MAX, BODY_FAT_MIN, WEIGHT_MAX, WEIGHT_MIN } from '@body-tracker/shared';
+import { memo, useEffect, useState } from 'react';
+import { InlineSpinner } from '../ui/LoadingSpinner';
+
+export interface RecordFormData {
+  weight: number;
+  bodyFatPercentage: number;
+  date: string;
+}
+
+export interface RecordFormProps {
+  initialValues?: Partial<RecordFormData>;
+  onSubmit: (data: RecordFormData) => Promise<void>;
+  submitLabel?: string;
+  isSubmitting?: boolean;
+}
+
+export const RecordForm = memo(function RecordForm({
+  initialValues,
+  onSubmit,
+  submitLabel = '保存',
+  isSubmitting = false,
+}: RecordFormProps) {
+  const [weight, setWeight] = useState('');
+  const [bodyFat, setBodyFat] = useState('');
+  const [date, setDate] = useState(new Date().toISOString().split('T')[0]);
+
+  useEffect(() => {
+    if (initialValues) {
+      if (initialValues.weight) setWeight(initialValues.weight.toString());
+      if (initialValues.bodyFatPercentage) setBodyFat(initialValues.bodyFatPercentage.toString());
+      if (initialValues.date) setDate(initialValues.date.split('T')[0]);
+    }
+  }, [initialValues]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const weightNum = Number.parseFloat(weight);
+    const bodyFatNum = Number.parseFloat(bodyFat);
+
+    if (Number.isNaN(weightNum) || Number.isNaN(bodyFatNum)) {
+      alert('有効な数値を入力してください');
+      return;
+    }
+
+    if (weightNum < WEIGHT_MIN || weightNum > WEIGHT_MAX) {
+      alert(`体重は${WEIGHT_MIN}から${WEIGHT_MAX}の間で入力してください`);
+      return;
+    }
+
+    if (bodyFatNum < BODY_FAT_MIN || bodyFatNum > BODY_FAT_MAX) {
+      alert(`体脂肪率は${BODY_FAT_MIN}から${BODY_FAT_MAX}の間で入力してください`);
+      return;
+    }
+
+    await onSubmit({
+      weight: weightNum,
+      bodyFatPercentage: bodyFatNum,
+      date,
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {/* 日付入力 */}
+      <div>
+        <label htmlFor="date" className="block text-sm font-medium text-gray-700 mb-2">
+          日付
+        </label>
+        <input
+          type="date"
+          id="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm p-2 border"
+          required
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        {/* 体重入力 */}
+        <div>
+          <label htmlFor="weight" className="block text-sm font-medium text-gray-700 mb-2">
+            体重 (kg)
+          </label>
+          <input
+            type="number"
+            id="weight"
+            step="0.1"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm p-2 border"
+            placeholder="60.0"
+            required
+          />
+        </div>
+
+        {/* 体脂肪率入力 */}
+        <div>
+          <label htmlFor="bodyFat" className="block text-sm font-medium text-gray-700 mb-2">
+            体脂肪率 (%)
+          </label>
+          <input
+            type="number"
+            id="bodyFat"
+            step="0.1"
+            value={bodyFat}
+            onChange={(e) => setBodyFat(e.target.value)}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm p-2 border"
+            placeholder="20.0"
+            required
+          />
+        </div>
+      </div>
+
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50"
+      >
+        {isSubmitting ? <InlineSpinner /> : submitLabel}
+      </button>
+    </form>
+  );
+});

--- a/apps/frontend/src/hooks/useModal.ts
+++ b/apps/frontend/src/hooks/useModal.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+/**
+ * モーダル表示時のスクロールロックとEscapeキーによるクローズを管理するフック
+ * @param isOpen モーダルが開いているかどうか
+ * @param onClose クローズ時のコールバック
+ */
+export function useModal(isOpen: boolean, onClose?: () => void) {
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && onClose) onClose();
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen, onClose]);
+}

--- a/apps/frontend/src/ui/Modal.tsx
+++ b/apps/frontend/src/ui/Modal.tsx
@@ -1,0 +1,67 @@
+import { useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { useModal } from '../hooks/useModal';
+
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+export function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  footer,
+}: ModalProps): React.ReactElement | null {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useModal(isOpen, onClose);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 overflow-y-auto"
+      aria-labelledby="modal-title"
+      // biome-ignore lint/a11y/useSemanticElements: Modal implementation using div
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+        {/* 背景オーバーレイ */}
+        <div
+          ref={overlayRef}
+          className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+          aria-hidden="true"
+          onClick={onClose}
+          onKeyDown={(e) => e.key === 'Enter' && onClose()}
+        />
+
+        <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">
+          &#8203;
+        </span>
+
+        <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
+          {title && (
+            <div className="mb-4">
+              <h3 className="text-lg leading-6 font-medium text-gray-900" id="modal-title">
+                {title}
+              </h3>
+            </div>
+          )}
+          <div className="mt-2">{children}</div>
+          {footer && (
+            <div className="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
+              {footer}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/shared/src/validation.ts
+++ b/packages/shared/src/validation.ts
@@ -4,21 +4,27 @@ interface BodyRecordInput {
   date: string;
 }
 
+// バリデーション定数
+export const WEIGHT_MIN = 30;
+export const WEIGHT_MAX = 150;
+export const BODY_FAT_MIN = 1;
+export const BODY_FAT_MAX = 50;
+
 export const validateBodyRecord = (
   data: BodyRecordInput,
 ): { isValid: boolean; errors: string[] } => {
   const errors: string[] = [];
 
-  if (typeof data.weight !== 'number' || data.weight <= 0 || data.weight > 200) {
-    errors.push('体重は0から200の間で入力してください');
+  if (typeof data.weight !== 'number' || data.weight < WEIGHT_MIN || data.weight > WEIGHT_MAX) {
+    errors.push(`体重は${WEIGHT_MIN}kgから${WEIGHT_MAX}kgの間で入力してください`);
   }
 
   if (
     typeof data.bodyFatPercentage !== 'number' ||
-    data.bodyFatPercentage < 0 ||
-    data.bodyFatPercentage > 100
+    data.bodyFatPercentage < BODY_FAT_MIN ||
+    data.bodyFatPercentage > BODY_FAT_MAX
   ) {
-    errors.push('体脂肪率は0から100の間で入力してください');
+    errors.push(`体脂肪率は${BODY_FAT_MIN}%から${BODY_FAT_MAX}%の間で入力してください`);
   }
 
   if (!data.date || Number.isNaN(Date.parse(data.date))) {


### PR DESCRIPTION
# 記録の更新・削除機能の実装

## 概要
ユーザーが過去の記録を修正・削除できるようにしました。
また、誤操作時のデータ復旧を考慮し、削除処理は物理削除から**論理削除**に変更しています。
あわせて、記録入力フォームの共通化とバリデーションルールの統一を行いました。

## 変更点

### フロントエンド
- **記録編集機能**: 「最近の記録」リストから項目をクリックすると編集モーダルが開くようになりました。
- **削除機能**: 編集モーダル内に「削除」ボタンを追加しました。
- **コンポーネント共通化**:
  - `QuickRecordForm` (ダッシュボード用) と編集モーダルで共通して使える `RecordForm` コンポーネントを作成しました。
  - `React.memo` を使用して再レンダリングを抑制しています。
- **リファクタリング**:
  - モーダルの開閉・スクロールロック制御を `useModal` フックに切り出しました。
  - `Modal` コンポーネントに `footer` プロパティを追加し、ボタン配置を柔軟にしました。

### バックエンド
- **スキーマ変更**: `bodyRecords` テーブルに `deletedAt` カラムを追加しました。
- **API更新**:
  - `DELETE /api/records/:id`: レコードを削除せず、`deletedAt` にタイムスタンプを設定するように変更。
  - `GET /api/records`, `GET /api/stats`: `deletedAt` が `null` のレコードのみを返すようにフィルタリングを追加。
  - `PUT /api/records/:id`: 論理削除されたレコードの更新をブロック。

### 共通 (Shared)
- **バリデーション**:
  - 体重 (30kg~150kg) や体脂肪率 (1%~50%) の境界値を定数として定義し、フロントエンド・バックエンドで共有するようにしました。

## 確認方法
1. ダッシュボードの「最近の記録」から任意の行をクリックする。
2. モーダルが表示され、値を変更して「更新する」ボタンで保存できることを確認。
3. 再度モーダルを開き、「削除」ボタンで記録が一覧から消えることを確認。
4. データベースを確認し、該当レコードが物理的に消えず `deleted_at` が設定されていることを確認（任意）。

## 備考
- 今回の変更で `packages/shared` に変更が入っているため、デプロイ前に `pnpm build:shared` が必要です（CI/CD設定済みであれば自動で行われます）。
# 記録の更新・削除機能の実装

## 概要
ユーザーが過去の記録を修正・削除できるようにしました。
また、誤操作時のデータ復旧を考慮し、削除処理は物理削除から**論理削除**に変更しています。
あわせて、記録入力フォームの共通化とバリデーションルールの統一を行いました。

## 変更点

### フロントエンド
- **記録編集機能**: 「最近の記録」リストから項目をクリックすると編集モーダルが開くようになりました。
- **削除機能**: 編集モーダル内に「削除」ボタンを追加しました。
- **コンポーネント共通化**:
  - `QuickRecordForm` (ダッシュボード用) と編集モーダルで共通して使える `RecordForm` コンポーネントを作成しました。
  - `React.memo` を使用して再レンダリングを抑制しています。
- **リファクタリング**:
  - モーダルの開閉・スクロールロック制御を `useModal` フックに切り出しました。
  - `Modal` コンポーネントに `footer` プロパティを追加し、ボタン配置を柔軟にしました。

### バックエンド
- **スキーマ変更**: `bodyRecords` テーブルに `deletedAt` カラムを追加しました。
- **API更新**:
  - `DELETE /api/records/:id`: レコードを削除せず、`deletedAt` にタイムスタンプを設定するように変更。
  - `GET /api/records`, `GET /api/stats`: `deletedAt` が `null` のレコードのみを返すようにフィルタリングを追加。
  - `PUT /api/records/:id`: 論理削除されたレコードの更新をブロック。

### 共通 (Shared)
- **バリデーション**:
  - 体重 (30kg~150kg) や体脂肪率 (1%~50%) の境界値を定数として定義し、フロントエンド・バックエンドで共有するようにしました。

## 確認方法
1. ダッシュボードの「最近の記録」から任意の行をクリックする。
2. モーダルが表示され、値を変更して「更新する」ボタンで保存できることを確認。
3. 再度モーダルを開き、「削除」ボタンで記録が一覧から消えることを確認。
4. データベースを確認し、該当レコードが物理的に消えず `deleted_at` が設定されていることを確認（任意）。

## 備考
- 今回の変更で `packages/shared` に変更が入っているため、デプロイ前に `pnpm build:shared` が必要です（CI/CD設定済みであれば自動で行われます）。